### PR TITLE
支持 js 配置项

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ Configure in `config/theme.config.json`,
 }
 ```
 
+or configure in `config/theme.config.js`,
+
+```javascript
+module.exports = {
+  theme: [
+    {
+      theme: 'dark',
+      fileName: 'dark.css',
+    },
+    {
+      fileName: 'mingQing.css',
+      modifyVars: {
+        '@primary-color': '#13C2C2',
+      },
+    },
+  ],
+  // 是否压缩css
+  min: true,
+  // css module
+  isModule: true,
+  // 忽略 antd 的依赖
+  ignoreAntd: false,
+  // 忽略 pro-layout
+  ignoreProLayout: false,
+  // 不使用缓存
+  cache: true,
+};
+```
+
 you can get config in `window.umi_plugin_ant_themeVar`
 
 ## LICENSE

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,11 @@ export default function (api: IApi) {
   const themeConfigPath = winPath(join(api.paths.cwd, 'config/theme.config.json'));
   if (existsSync(themeConfigPath)) {
     options = require(themeConfigPath);
+  }else{
+    const themeConfigPath = winPath(join(api.paths.cwd, 'config/theme.config.js'));
+    if (existsSync(themeConfigPath)) {
+      options = require(themeConfigPath);
+    }
   }
   const { cwd, absOutputPath, absNodeModulesPath } = api.paths;
   const outputPath = absOutputPath;


### PR DESCRIPTION
用于弥补 json 配置项无法配置方法的缺陷。

umi-plugin-antd-theme 调用 antd-pro-merge-less 库的 build 方法时，会将当前所有配置项传入。antd-pro-merge-less 支持配置 filterFileLess 方法用于过滤一些 less 文件。在 json 配置项中无法配置该方法，而 js 配置项可以。所以增加对 js 配置项的支持。