### PR TITLE
chore: add umi3 to peer-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": "https://github.com/chenshuai2144/umi-plugin-ant-theme.git",
   "peerDependencies": {
-    "umi": "2.x || ^2.9.0-0"
+    "umi": "2.x || ^2.9.0-0 || 3.x"
   },
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
现在umi3的项目有用这个插件，在npm@7下会有peer报错，用force的话也会改变很多包结构。
所以想peer支持下umi3