### PR TITLE
fix: path may not find when use lerna

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export default function (api: IApi) {
   }
   const { cwd, absOutputPath, absNodeModulesPath } = api.paths;
   const outputPath = absOutputPath;
-  const themeTemp = winPath(join(absNodeModulesPath, '.plugin-theme'));
+  const themeTemp = winPath(join(__dirname, '../../.plugin-theme'));
 
   // 增加中间件
   api.addMiddewares(() => {


### PR DESCRIPTION
当使用lerna 将nodemodule提取到根目录时，该插件调用的nodemodule的位置如果没有存在nodemodule文件夹则会报错，所以使用相对路径找到该插件所安装位置确保肯定存在nodemodule